### PR TITLE
Fixed chat for login, enter key press, page refresh, styles for chat

### DIFF
--- a/src/scripts/chatAPI.js
+++ b/src/scripts/chatAPI.js
@@ -3,6 +3,7 @@ import chatScreenFunctions from './chatScreenFunctions.js';
 // Creating a variable for the user IDs of the users in the system to
 // be used when comparing / looping through IDs for messages the user can edit or dlete
 let chatUserIDs;
+let currentUser = parseInt(sessionStorage.userId, 10)
 // Creating an object for storing the chat api functions
 const chatAPI = {
 	// Get user IDs first and store them?
@@ -19,7 +20,6 @@ const chatAPI = {
 	// Creating a function to get all the chat messages
 	getChatMessages: () => {
 		// Setting current user as userId from session storage
-		let currentUser = parseInt(sessionStorage.userId, 10);
 		// Fetching all the messages
 		fetch(`http://localhost:8088/messages`).then((messages) => messages.json()).then((parsedMessages) => {
 			// Declaring the chat username to the username of the userID

--- a/src/scripts/chatEventListeners.js
+++ b/src/scripts/chatEventListeners.js
@@ -1,5 +1,8 @@
 // Importing the chat api functions
 import chatAPI from './chatAPI.js';
+// Setting the current user via sessionStorage
+let currentUser = parseInt(sessionStorage.userId, 10);
+
 // Creating an object for the event listener functions
 const chatEventListeners = {
 	// Creating a function to load the chat page
@@ -24,7 +27,7 @@ const chatEventListeners = {
 		let time =
 			today.getDate() +
 			'/' +
-			(today.getMonth()+1) +
+			(today.getMonth() + 1) +
 			'/' +
 			today.getFullYear() +
 			' at ' +
@@ -34,7 +37,7 @@ const chatEventListeners = {
 			`:` +
 			today.getSeconds();
 		const messageToSend = {
-			userId: 1,
+			userId: currentUser,
 			message: chatMessage,
 			time: time
 		};

--- a/src/scripts/login.js
+++ b/src/scripts/login.js
@@ -1,9 +1,10 @@
-import registerDomPrinter from './registerDomPrinter.js'
-import registerEventListener from './registerEventListener.js'
+import registerDomPrinter from './registerDomPrinter.js';
+import registerEventListener from './registerEventListener.js';
+import chatEventListeners from './chatEventListeners.js';
 
 //The HTML for the email and password in the modal
 const loginForm = () => {
-    return `
+	return `
     <label for="email"><b>Email</b></label>
     <input type="text" placeholder="Enter Email" id="login-email" name="email" required>
 
@@ -12,75 +13,74 @@ const loginForm = () => {
 
     <button id="login-btn" class="login-btn">Login</button>
 
-    `
-}
-
+    `;
+};
 
 const nutLogin = {
-    //Launches the login modal by changing the display to block
-    activateModal() {
-        document.querySelector('#login-modal').style.display = 'block';
-    },
-    //listens for the login button and attempts to log in with that email and password
-    loginEventListenter() {
-        document.querySelector('#login-btn').addEventListener("click", () => {
-            const emailValue = document.querySelector("#login-email").value;
-            const passwordValue = document.querySelector("#login-password").value;
+	//Launches the login modal by changing the display to block
+	activateModal() {
+		document.getElementById('logout').style.display = 'none';
+		document.querySelector('#login-modal').style.display = 'block';
+	},
+	//listens for the login button and attempts to log in with that email and password
+	loginEventListenter() {
+		document.querySelector('#login-btn').addEventListener('click', () => {
+			const emailValue = document.querySelector('#login-email').value;
+			const passwordValue = document.querySelector('#login-password').value;
 
-            //fetches any user with the an email and password matching the inputs
-            fetch(`http://localhost:8088/users?email=${emailValue}&password=${passwordValue}`)
-                .then((r) => r.json())
-                .then((user) => {
-                    //If a user is returned
-                    if (user.length != 0) {
-                        //Sets the userId in session storage to the id of the user that was fetched, deactivates the modal, and clears the values in the form
-                        sessionStorage.setItem("userId", user[0].id);
-                        nutLogin.deactivateModal();
-                        document.querySelector("#login-email").value = "";
-                        document.querySelector("#login-password").value = "";
+			//fetches any user with the an email and password matching the inputs
+			fetch(`http://localhost:8088/users?email=${emailValue}&password=${passwordValue}`)
+				.then((r) => r.json())
+				.then((user) => {
+					//If a user is returned
+					if (user.length != 0) {
+						//Sets the userId in session storage to the id of the user that was fetched, deactivates the modal, and clears the values in the form
+						sessionStorage.setItem('userId', user[0].id);
+						nutLogin.deactivateModal();
+						// Forcing reload of page to refresh and clear the user correctly
+						location.reload(true);
+						document.querySelector('#login-email').value = '';
+						document.querySelector('#login-password').value = '';
 
-                        //If it didn't find a match it returns an error message
-                    } else {
-                        document.querySelector("#login-error-container").innerHTML = "email or password is incorrect!"
-                        
-                    }
-                }
-                )
+						//If it didn't find a match it returns an error message
+					} else {
+						document.querySelector('#login-error-container').innerHTML = 'email or password is incorrect!';
+					}
+				});
+		});
+	},
+	//Deactiaves the modal by setting the display to none
+	deactivateModal() {
+		document.querySelector('#login-modal').style.display = 'none';
+	},
 
-        })
-    },
-    //Deactiaves the modal by setting the display to none
-    deactivateModal() {
-        document.querySelector('#login-modal').style.display = 'none';
-    },
+	registerLinkListener() {
+		document.querySelector('#register-link').addEventListener('click', () => {
+			// Directing the user to the register form page when the site loads
+			registerDomPrinter.printRegisterForm();
+			document.querySelector(`#register-user-submit`).addEventListener('click', (clickEvent) => {
+				registerEventListener.submitRegisterForm();
+			});
+		});
+	},
 
-    registerLinkListener() {
-        document.querySelector('#register-link').addEventListener("click", () => {
-            
-            // Directing the user to the register form page when the site loads
-            registerDomPrinter.printRegisterForm()
-            document.querySelector(`#register-user-submit`).addEventListener("click", clickEvent => {
-                registerEventListener.submitRegisterForm();
-        
-            })
-        })
-    },
+	//Prints the login form in the modal.  This method is used after an account is successfully registered.
+	loginFormPrinter() {
+		document.getElementById('logout').style.display = 'none';
+		document.querySelector(`#login-container`).innerHTML = loginForm();
+	},
 
-    //Prints the login form in the modal.  This method is used after an account is successfully registered.
-    loginFormPrinter() {
-        document.querySelector(`#login-container`).innerHTML = loginForm()
-    },
+	//Listens for the logout button, sets the userId in session storage to null, and activates the login modal.
+	logoutListener() {
+		document.querySelector('#logout').addEventListener('click', () => {
+			sessionStorage.setItem('userId', null);
+			sessionStorage.clear();
+			// Redirecting to splash page
+			window.location.href = 'http://127.0.0.1:5500/';
+			// Forcing reload of page
+			location.reload(true);
+		});
+	}
+};
 
-    //Listens for the logout button, sets the userId in session storage to null, and activates the login modal.
-    logoutListener() {
-        document.querySelector("#logout").addEventListener("click", () => {
-            sessionStorage.setItem("userId", null);
-            nutLogin.activateModal();
-        })
-    }
-
-}
-
-
-
-export default nutLogin
+export default nutLogin;

--- a/src/scripts/login.js
+++ b/src/scripts/login.js
@@ -59,7 +59,10 @@ const nutLogin = {
 			// Directing the user to the register form page when the site loads
 			registerDomPrinter.printRegisterForm();
 			document.querySelector(`#register-user-submit`).addEventListener('click', (clickEvent) => {
-				registerEventListener.submitRegisterForm();
+                registerEventListener.submitRegisterForm();
+                // nutLogin.loginFormPrinter()
+                location.reload(true);
+                window.location.href = 'http://127.0.0.1:5500/'
 			});
 		});
 	},

--- a/src/scripts/login.js
+++ b/src/scripts/login.js
@@ -61,8 +61,7 @@ const nutLogin = {
 			document.querySelector(`#register-user-submit`).addEventListener('click', (clickEvent) => {
                 registerEventListener.submitRegisterForm();
                 // nutLogin.loginFormPrinter()
-                location.reload(true);
-                window.location.href = 'http://127.0.0.1:5500/'
+                
 			});
 		});
 	},

--- a/src/scripts/registerFetchFunctions.js
+++ b/src/scripts/registerFetchFunctions.js
@@ -37,7 +37,9 @@ const registerFetchFunctions = {
 								},
 								body: JSON.stringify(userObject)
 							}).then(() => {
-								nutLogin.loginFormPrinter();
+								location.reload(true);
+                				window.location.href = 'http://127.0.0.1:5500/'
+
 							});
 							// If username is taken then prints error message
 						} else if (userBoolean === false) {

--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -1,31 +1,28 @@
-import event_eventListener from "./event-eventListeners.js"
-import nutLogin from './login.js'
-
-
+import event_eventListener from './event-eventListeners.js';
+import nutLogin from './login.js';
+import registerEventListener from './registerEventListener.js';
 
 // sessionStorage.setItem("userId", 1)
 // sessionStorage.setItem("username", "user1")
 
-if (sessionStorage.getItem("userId") == null){
-	nutLogin.activateModal()
-} 
+if (sessionStorage.getItem('userId') == null) {
+	nutLogin.activateModal();
+}
 
 nutLogin.loginEventListenter();
 nutLogin.registerLinkListener();
 nutLogin.logoutListener();
 //Calling all event listeners for 'Events'
-event_eventListener.eventsPageListener()
-event_eventListener.addNewEventListener()
-event_eventListener.deleteEventListener()
-event_eventListener.editEventListener()
-event_eventListener.saveEventListener()
+event_eventListener.eventsPageListener();
+event_eventListener.addNewEventListener();
+event_eventListener.deleteEventListener();
+event_eventListener.editEventListener();
+event_eventListener.saveEventListener();
 
 // Importing the chat event listener functions
 import chatEventListeners from './chatEventListeners.js';
 // Importing the chat api functions
 import chatAPI from './chatAPI.js';
-
-
 
 // Creating an event listener for when the user clicks on the chat tab on the nav bar
 document.querySelector(`#chat-page`).addEventListener('click', (chatEvent) => {
@@ -56,26 +53,35 @@ document.getElementById('output-container').onkeydown = function(e) {
 		}
 	}
 };
-
+// Creating event listeners for enter key press on the register and login screens
+document.getElementById(`login-container`).onkeydown = function(e) {
+	if (e.keyCode == 13) {
+		if (event.target.id.includes(`register-password`)) {
+			registerEventListener.submitRegisterForm();
+		} else if (event.target.id.includes(`login-password`)) {
+			event.preventDefault();
+			document.getElementById('login-btn').click();
+		}
+	}
+};
 
 //Imports functions for DOM printing and EventListeners
-import newsPrinterFunctions from "./newsPrinter.js";
-import newsListenFunctions from "./newsListeners.js";
-import tasksEvents from "./tasksEventListener.js";
+import newsPrinterFunctions from './newsPrinter.js';
+import newsListenFunctions from './newsListeners.js';
+import tasksEvents from './tasksEventListener.js';
 
 //If the News link in the Nav Bar is clicked, call a function to print the News section
-document.querySelector("#news-page").addEventListener("click", function() {
-    newsPrinterFunctions.printInitialPage();
-})
+document.querySelector('#news-page').addEventListener('click', function() {
+	newsPrinterFunctions.printInitialPage();
+});
 
 //Checks which buttons are being clicked in the News section
-document.querySelector("#output-container").addEventListener("click", function() {
-        newsListenFunctions.checkButton();
-    })
+document.querySelector('#output-container').addEventListener('click', function() {
+	newsListenFunctions.checkButton();
+});
 
 tasksEvents.tasksEventListener();
 
 tasksEvents.tasksPageEventListeners();
 
 tasksEvents.taskEditKeypressListener();
-   

--- a/src/style.css
+++ b/src/style.css
@@ -80,6 +80,12 @@ article:first-child{
     align-items: center;
     margin-left: 1em;
 }
+#chat-output button{
+    color: #fff;
+    background-color: #0069d9;
+    border-color: #0062cc;
+    border-radius: 5 px;
+}
 .edit-chat-message{
     margin-left: 2em;
     font-size: 15px;


### PR DESCRIPTION
What I did:
-Made chat page work with login
-Had to add a refresh to the page after logging out/in to get the correct user to show up in chat.
**This issue was only visible is switching users during the same session/computer**
-Added on enter press for register and login form.
-Styled chat page buttons.
-Made the logout nav link hide when the user is logged out. 

What to expect:
-When registering or logging in the user can now press the enter key on the last line instead of having to click on the button.
-When logged in the proper user will show in chat and they will be able to post, edit, and delete their messages.
-When the user logs out the logout nav link disappears

Note:
This should have been multiple branches but I did one single one for the sake of time and trying to merge multiple times.